### PR TITLE
removing extraneous x509

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1671,14 +1671,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "x509": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/x509/-/x509-0.3.4.tgz",
-      "integrity": "sha512-in6y2bl0kGHDMG4rD4Zzu5UH/4wAIiTXNwlrVOhBCyDptQmUujDHy0O60y8Nalb/p4Y0nsIbg70amKrCyZC9Ew==",
-      "requires": {
-        "nan": "2.12.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "hex-to-binary": "^1.0.1",
     "jsrsasign": "^8.0.12",
     "uuid": "^3.3.2",
-    "uuid-parse": "^1.1.0",
-    "x509": "^0.3.4"
+    "uuid-parse": "^1.1.0"
   },
   "devDependencies": {
     "mocha": "^5.2.0",


### PR DESCRIPTION
This PR removes `x509` as a dependency. 

`x509` isn't being `require`d anywhere and all tests pass without it. This is causing a build error for me on both mac and a raspberry pi and is fixed without this dependency. 
